### PR TITLE
feat: Add CI/CD workflow for PDF and arXiv submission build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: Deploy PDF
 
 on:
   push:
-    # branches:
-    # - main
+    branches:
+    - main
   pull_request:
     branches:
     - main
@@ -46,7 +46,7 @@ jobs:
         path: 'chep_2023_proceedings.pdf'
 
     - name: Build arXiv archive
-      # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: xu-cheng/texlive-action/full@v1
       with:
         run: |
@@ -54,12 +54,12 @@ jobs:
           make arXiv
 
     - name: Unpack archive
-      # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       run: |
         tar -xzvf submit_to_arXiv.tar.gz
 
     - name: Upload arXiv archive
-      # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v3
       with:
         name: submit_to_arXiv
@@ -71,7 +71,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: [build]
-    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Setup Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: Deploy PDF
 
 on:
   push:
-    branches:
-    - main
+    # branches:
+    # - main
   pull_request:
     branches:
     - main
@@ -46,7 +46,7 @@ jobs:
         path: 'chep_2023_proceedings.pdf'
 
     - name: Build arXiv archive
-      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: xu-cheng/texlive-action/full@v1
       with:
         run: |
@@ -54,12 +54,12 @@ jobs:
           make arXiv
 
     - name: Unpack archive
-      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       run: |
         tar -xzvf submit_to_arXiv.tar.gz
 
     - name: Upload arXiv archive
-      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v3
       with:
         name: submit_to_arXiv
@@ -71,7 +71,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    # if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
 
     steps:
     - name: Setup Pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: Deploy PDF
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Compile LaTeX document
+      uses: xu-cheng/texlive-action/full@v1
+      with:
+        run: |
+          apk add make
+          make document
+
+    - name: List directory
+      run: |
+        ls -lhtra
+
+    - name: Upload pdf
+      uses: actions/upload-artifact@v3
+      with:
+        name: proceedings
+        path: 'chep_2023_proceedings.pdf'
+
+    - name: Build arXiv archive
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      uses: xu-cheng/texlive-action/full@v1
+      with:
+        run: |
+          apk add make
+          make arXiv
+
+    - name: Unpack archive
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      run: |
+        tar -xzvf submit_to_arXiv.tar.gz
+
+    - name: Upload arXiv archive
+      if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+      uses: actions/upload-artifact@v3
+      with:
+        name: submit_to_arXiv
+        path: 'submit_to_arXiv'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+
+    steps:
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+
+    - name: Create site directory structure
+      run: |
+        mkdir -p _site/
+        touch _site/index.html
+        touch _site/.nojekyll
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: proceedings
+        path: '_site/'
+
+    - name: Check site structure
+      run: |
+        tree _site
+
+    - name: Fix permissions
+      run: |
+        chmod -c -R +rX "_site/" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v2
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v2


### PR DESCRIPTION
```
* Add GitHub Actions based CI/CD workflow
   - Build PDF and deploy to GitHub pages.
   - Build arXiv submission archive and upload for download.
```