### PR TITLE
fix: Use lmodern to match fonts and layout

### DIFF
--- a/latex/packages.tex
+++ b/latex/packages.tex
@@ -5,6 +5,8 @@
 \RequirePackage{caption}
 \RequirePackage{subcaption}  % Needed for subfigures
 \usepackage[capitalize]{cleveref}% https://ctan.org/pkg/cleveref % Must be loaded after hyperref
+\usepackage{lineno}
+\usepackage{lmodern}% https://www.ctan.org/pkg/lm % Use same fonts as journal submission and match layout
 
 \hypersetup{bookmarksnumbered=true, bookmarksopen=true, bookmarksopenlevel=0}
 \hypersetup{pdftitle={Bayesian Methodologies with pyhf}, pdfauthor={Matthew Feickert, Lukas Heinrich, Malin Horstman}}


### PR DESCRIPTION
* Add lineno to be able to add line numbers during editing.
* Add lmodern to packages to match the fonts used for math, as well as the overall layout of the paper, that was submitted to the journal.