### PR TITLE
fix: Add sed to Alpine linux environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: xu-cheng/texlive-action/full@v1
       with:
         run: |
-          apk add make
+          apk add make sed
           make arXiv
 
     - name: Unpack archive


### PR DESCRIPTION
Resolves #7 

* Update sed to a recent version that will be compatible with sed commands used in arXiv Make target.